### PR TITLE
prysm: use shell as for validator cmd

### DIFF
--- a/charts/prysm/ci/validator-values.yaml
+++ b/charts/prysm/ci/validator-values.yaml
@@ -2,9 +2,6 @@ replicas: 1
 
 mode: validator
 
-image:
-  repository: gcr.io/prysmaticlabs/prysm/validator
-
 initContainers:
   - name: init-keystore
     image: bash:latest

--- a/charts/prysm/templates/_cmd.tpl
+++ b/charts/prysm/templates/_cmd.tpl
@@ -36,12 +36,15 @@
 # Validator command
 */}}
 {{- define "prysm.validatorCommand" -}}
-- /app/cmd/validator/validator
-- --accept-terms-of-use=true
-- --datadir=/data
-- --monitoring-host=0.0.0.0
-- --monitoring-port={{ include "prysm.metricsPort" . }}
+- sh
+- -ac
+- >-
+  exec /app/cmd/validator/validator
+  --accept-terms-of-use=true
+  --datadir=/data
+  --monitoring-host=0.0.0.0
+  --monitoring-port={{ include "prysm.metricsPort" . }}
 {{- range .Values.extraArgs }}
--  {{ . }}
+  {{ . }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
so that we can use shell commands on extraArgs if needed.