### PR TITLE
beaconchain-explorer: allocate disk space and define psql db by default

### DIFF
--- a/charts/beaconchain-explorer/README.md
+++ b/charts/beaconchain-explorer/README.md
@@ -56,6 +56,9 @@ Beacon chain explorer built using golang and using a PostgreSQL database for sto
 | postgresql.initdbPassword | string | `"postgres"` |  |
 | postgresql.initdbScripts | object | See `values.yaml` | How to init the PSQL DB |
 | postgresql.initdbUser | string | `"postgres"` |  |
+| postgresql.persistence.enabled | bool | `true` |  |
+| postgresql.persistence.size | string | `"8Gi"` |  |
+| postgresql.postgresqlDatabase | string | `"explorer"` |  |
 | postgresql.postgresqlPassword | string | `"postgres"` |  |
 | postgresql.postgresqlUsername | string | `"postgres"` |  |
 | postgresql.pullPolicy | string | `"IfNotPresent"` |  |

--- a/charts/beaconchain-explorer/values.yaml
+++ b/charts/beaconchain-explorer/values.yaml
@@ -220,8 +220,12 @@ postgresql:
   pullPolicy: IfNotPresent
   initdbUser: postgres
   initdbPassword: postgres
+  postgresqlDatabase: explorer
   postgresqlUsername: postgres
   postgresqlPassword: postgres
+  persistence:
+    enabled: true
+    size: 8Gi
   # -- How to init the PSQL DB
   # @default -- See `values.yaml`
   initdbScripts:


### PR DESCRIPTION
`postgresqlDatabase: explorer` is needed for the serviceMonitor to work.