### PR TITLE
nethermind: make nodePort work, with its limitations to a single replica

### DIFF
--- a/charts/nethermind/Chart.yaml
+++ b/charts/nethermind/Chart.yaml
@@ -7,7 +7,7 @@ icon: https://launchpad.ethereum.org/static/media/nethermind-circle.fbbf1a32.png
 sources:
   - https://github.com/NethermindEth/nethermind
 type: application
-version: 0.1.1
+version: 0.2.0
 maintainers:
   - name: skylenet
     email: rafael@skyle.net

--- a/charts/nethermind/README.md
+++ b/charts/nethermind/README.md
@@ -1,7 +1,7 @@
 
 # nethermind
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Nethermind is an Ethereum execution layer implementation created with the C# .NET tech stack, running on all major platforms including ARM.
 
@@ -47,11 +47,10 @@ Nethermind is an Ethereum execution layer implementation created with the C# .NE
 | p2pNodePort.initContainer.image.pullPolicy | string | `"IfNotPresent"` | Container pull policy |
 | p2pNodePort.initContainer.image.repository | string | `"lachlanevenson/k8s-kubectl"` | Container image to fetch nodeport information |
 | p2pNodePort.initContainer.image.tag | string | `"v1.21.3"` | Container tag |
+| p2pNodePort.port | int | `31000` | NodePort to be used |
 | p2pNodePort.portForwardContainer.image.pullPolicy | string | `"IfNotPresent"` | Container pull policy |
 | p2pNodePort.portForwardContainer.image.repository | string | `"alpine/socat"` | Container image for the port forwarder |
 | p2pNodePort.portForwardContainer.image.tag | string | `"latest"` | Container tag |
-| p2pNodePort.portsOverwrite | object | See `values.yaml` for example | Overwrite a port for specific replicas |
-| p2pNodePort.startAt | int | `31000` | Port used to start |
 | persistence.accessModes | list | `["ReadWriteOnce"]` | Access mode for the volume claim template |
 | persistence.annotations | object | `{}` | Annotations for volume claim template |
 | persistence.enabled | bool | `false` | Uses an EmptyDir when not enabled |
@@ -101,21 +100,16 @@ extraArgs:
 
 ## Exposing the P2P service via NodePort
 
-This will make your nodes accessible via the Internet using services of type [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport). It will allocate a service definition and a pre-defined node port for each replica. The allocation starts at `p2pNodePort.startAt`. When using `p2pNodePort.enabled` the exposed IP address on your ENR record will be the "External IP" of the node where the pod is running.
+This will make your node accessible via the Internet using a service of type [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport).
+When using `p2pNodePort.enabled` the exposed IP address on your ENR record will be the "External IP" of the node where the pod is running.
+
+**Limitations:** You can only run a single replica per chart deployment when using `p2pNodePort.enabled=true`.If you need N nodes, simply deploy the chart N times.
+Currently nethermind doesn't allow you to announce a a different discovery port, which would be a requirement to run multiple replicas within the same chart.
 
 ```yaml
-replicas: 5
+replicas: 1
 
 p2pNodePort:
   enabled: true
-  startAt: 30000
-  portsOverwrite:
-    "3": 32000
+  port: 31000
 ```
-
-This would create 5 nodes, exposed via Node Port services with the following configuration:
-- Node 0: `30000`
-- Node 1: `30001`
-- Node 2: `30002`
-- Node 3: `32000`
-- Node 4: `30004`

--- a/charts/nethermind/README.md.gotmpl
+++ b/charts/nethermind/README.md.gotmpl
@@ -26,21 +26,16 @@ extraArgs:
 
 ## Exposing the P2P service via NodePort
 
-This will make your nodes accessible via the Internet using services of type [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport). It will allocate a service definition and a pre-defined node port for each replica. The allocation starts at `p2pNodePort.startAt`. When using `p2pNodePort.enabled` the exposed IP address on your ENR record will be the "External IP" of the node where the pod is running.
+This will make your node accessible via the Internet using a service of type [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport).
+When using `p2pNodePort.enabled` the exposed IP address on your ENR record will be the "External IP" of the node where the pod is running.
+
+**Limitations:** You can only run a single replica per chart deployment when using `p2pNodePort.enabled=true`.If you need N nodes, simply deploy the chart N times.
+Currently nethermind doesn't allow you to announce a a different discovery port, which would be a requirement to run multiple replicas within the same chart.
 
 ```yaml
-replicas: 5
+replicas: 1
 
 p2pNodePort:
   enabled: true
-  startAt: 30000
-  portsOverwrite:
-    "3": 32000
+  port: 31000
 ```
-
-This would create 5 nodes, exposed via Node Port services with the following configuration:
-- Node 0: `30000`
-- Node 1: `30001`
-- Node 2: `30002`
-- Node 3: `32000`
-- Node 4: `30004`

--- a/charts/nethermind/templates/_helpers.tpl
+++ b/charts/nethermind/templates/_helpers.tpl
@@ -62,7 +62,11 @@ Create the name of the service account to use
 {{- end }}
 
 {{- define "nethermind.p2pPort" -}}
+{{- if .Values.p2pNodePort.enabled }}
+{{- print .Values.p2pNodePort.port }}
+{{- else }}
 {{- printf "30303" -}}
+{{- end }}
 {{- end -}}
 
 {{- define "nethermind.httpPort" -}}
@@ -71,4 +75,12 @@ Create the name of the service account to use
 
 {{- define "nethermind.metricsPort" -}}
 {{- printf "9545" -}}
+{{- end -}}
+
+{{- define "nethermind.replicas" -}}
+{{- if .Values.p2pNodePort.enabled }}
+{{- print 1 }}
+{{ else }}
+{{- print .Values.replicas }}
+{{- end}}
 {{- end -}}

--- a/charts/nethermind/templates/service.p2p.nodeport.yaml
+++ b/charts/nethermind/templates/service.p2p.nodeport.yaml
@@ -1,19 +1,14 @@
 {{- if .Values.p2pNodePort.enabled -}}
 
-{{- range $i, $e := until (int $.Values.replicas) }}
-
-{{- $port := add $.Values.p2pNodePort.startAt $i -}}
-{{- if hasKey $.Values.p2pNodePort.portsOverwrite ($i | toString) -}}
-  {{ $port = index $.Values.p2pNodePort.portsOverwrite ($i | toString) }}
-{{- end }}
+{{- $port := $.Values.p2pNodePort.port -}}
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "nethermind.fullname" $ }}-p2p-{{ $i }}
+  name: {{ include "nethermind.fullname" $ }}-p2p-0
   labels:
     {{- include "nethermind.labels" $ | nindent 4 }}
-    pod: {{ include "nethermind.fullname" $ }}-{{ $i }}
+    pod: {{ include "nethermind.fullname" $ }}-0
     type: p2p
 spec:
   type: NodePort
@@ -31,8 +26,5 @@ spec:
       nodePort: {{ $port }}
   selector:
     {{- include "nethermind.selectorLabels" $ | nindent 4 }}
-    statefulset.kubernetes.io/pod-name: {{ include "nethermind.fullname" $ }}-{{ $i }}
-
-{{- end }}
-
+    statefulset.kubernetes.io/pod-name: "{{ include "nethermind.fullname" $ }}-0"
 {{- end }}

--- a/charts/nethermind/templates/statefulset.yaml
+++ b/charts/nethermind/templates/statefulset.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- toYaml .Values.annotations | nindent 4 }}
 spec:
   podManagementPolicy: {{ .Values.podManagementPolicy }}
-  replicas: {{ .Values.replicas }}
+  replicas: {{ include "nethermind.replicas" . }}
   selector:
     matchLabels:
       {{- include "nethermind.selectorLabels" . | nindent 6 }}
@@ -111,14 +111,12 @@ spec:
             - name: storage
               mountPath: "/data"
           ports:
-          {{- if not (.Values.p2pNodePort.enabled) }}
             - name: p2p-tcp
               containerPort: {{ include "nethermind.p2pPort" . }}
               protocol: TCP
             - name: p2p-udp
               containerPort: {{ include "nethermind.p2pPort" . }}
               protocol: UDP
-          {{- end }}
             - name: http-rpc
               containerPort: {{ include "nethermind.httpPort" . }}
               protocol: TCP
@@ -150,42 +148,6 @@ spec:
           {{- if .Values.extraEnv }}
             {{- toYaml .Values.extraEnv | nindent 12 }}
           {{- end }}
-      {{- if .Values.p2pNodePort.enabled }}
-        - name: port-forward-p2p-udp
-          image: "{{ .Values.p2pNodePort.portForwardContainer.image.repository }}:{{ .Values.p2pNodePort.portForwardContainer.image.tag }}"
-          imagePullPolicy: "{{ .Values.p2pNodePort.portForwardContainer.image.pullPolicy }}"
-          command:
-            - sh
-            - -ac
-            - >
-              . /env/init-nodeport;
-              exec socat udp4-recvfrom:{{ include "nethermind.p2pPort" . }},fork "udp4-sendto:localhost:$EXTERNAL_PORT"
-          ports:
-            - name: p2p-udp
-              containerPort: {{ include "nethermind.p2pPort" . }}
-              protocol: UDP
-          volumeMounts:
-            - name: env-nodeport
-              mountPath: /env
-              readOnly: true
-        - name: port-forward-p2p-tcp
-          image: "{{ .Values.p2pNodePort.portForwardContainer.image.repository }}:{{ .Values.p2pNodePort.portForwardContainer.image.tag }}"
-          imagePullPolicy: "{{ .Values.p2pNodePort.portForwardContainer.image.pullPolicy }}"
-          command:
-            - sh
-            - -ac
-            - >
-              . /env/init-nodeport;
-              exec socat tcp-listen:{{ include "nethermind.p2pPort" . }},reuseaddr,fork "tcp:localhost:$EXTERNAL_PORT"
-          ports:
-            - name: p2p-tcp
-              containerPort: {{ include "nethermind.p2pPort" . }}
-              protocol: TCP
-          volumeMounts:
-            - name: env-nodeport
-              mountPath: /env
-              readOnly: true
-      {{- end }}
       {{- if .Values.extraContainers }}
         {{ toYaml .Values.extraContainers | nindent 8}}
       {{- end }}

--- a/charts/nethermind/values.yaml
+++ b/charts/nethermind/values.yaml
@@ -23,18 +23,14 @@ extraArgs: []
 customCommand: [] # Only change this if you need to change the default command
 
 # When p2pNodePort is enabled, your P2P port will be exposed via service type NodePort.
-# This will generate a service for each replica, with a port binding via NodePort.
 # This is useful if you want to expose and announce your node to the Internet.
+# Limitation: You can only one have one replica when exposing via NodePort.
+#             Check the chart README.md for more details
 p2pNodePort:
   # -- Expose P2P port via NodePort
   enabled: false
-  # -- Port used to start
-  startAt: 31000
-  # -- Overwrite a port for specific replicas
-  # @default -- See `values.yaml` for example
-  portsOverwrite: {}
-  #  "0": 32345
-  #  "3": 32348
+  # -- NodePort to be used
+  port: 31000
   initContainer:
     image:
       # -- Container image to fetch nodeport information


### PR DESCRIPTION
NodePort with the intermediary socat proxy wasn't working well with the P2P layer. This change has the limitation that you can only run 1 Replica when using NodePort, but that can be worked around by deploying the chart multiple times.