### PR TITLE
erigon: make nodePort work, with its limitations to a single replica

### DIFF
--- a/charts/erigon/Chart.yaml
+++ b/charts/erigon/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://pbs.twimg.com/profile_images/1420080204148576274/-4OFIs2x_400x400.
 sources:
   - https://github.com/ledgerwatch/erigon
 type: application
-version: 0.1.1
+version: 0.2.0
 maintainers:
   - name: skylenet
     email: rafael@skyle.net

--- a/charts/erigon/README.md
+++ b/charts/erigon/README.md
@@ -1,7 +1,7 @@
 
 # erigon
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Erigon, formerly known as Turbo‐Geth, is a fork of Go Ethereum (geth) oriented toward speed and disk‐space efficiency. Erigon is a completely re-architected implementation of Ethereum, currently written in Go but with implementations in other languages planned. Erigon's goal is to provide a faster, more modular, and more optimized implementation of Ethereum.
 
@@ -50,11 +50,10 @@ Erigon, formerly known as Turbo‐Geth, is a fork of Go Ethereum (geth) oriented
 | p2pNodePort.initContainer.image.pullPolicy | string | `"IfNotPresent"` | Container pull policy |
 | p2pNodePort.initContainer.image.repository | string | `"lachlanevenson/k8s-kubectl"` | Container image to fetch nodeport information |
 | p2pNodePort.initContainer.image.tag | string | `"v1.21.3"` | Container tag |
+| p2pNodePort.port | int | `31000` | NodePort to be used |
 | p2pNodePort.portForwardContainer.image.pullPolicy | string | `"IfNotPresent"` | Container pull policy |
 | p2pNodePort.portForwardContainer.image.repository | string | `"alpine/socat"` | Container image for the port forwarder |
 | p2pNodePort.portForwardContainer.image.tag | string | `"latest"` | Container tag |
-| p2pNodePort.portsOverwrite | object | See `values.yaml` for example | Overwrite a port for specific replicas |
-| p2pNodePort.startAt | int | `31000` | Port used to start |
 | persistence.accessModes | list | `["ReadWriteOnce"]` | Access mode for the volume claim template |
 | persistence.annotations | object | `{}` | Annotations for volume claim template |
 | persistence.enabled | bool | `false` | Uses an EmptyDir when not enabled |
@@ -105,24 +104,19 @@ extraArgs:
 
 ## Exposing the P2P service via NodePort
 
-This will make your nodes accessible via the Internet using services of type [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport). It will allocate a service definition and a pre-defined node port for each replica. The allocation starts at `p2pNodePort.startAt`. When using `p2pNodePort.enabled` the exposed IP address on your ENR record will be the "External IP" of the node where the pod is running.
+This will make your node accessible via the Internet using a service of type [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport).
+When using `p2pNodePort.enabled` the exposed IP address on your ENR record will be the "External IP" of the node where the pod is running.
+
+**Limitations:** You can only run a single replica per chart deployment when using `p2pNodePort.enabled=true`.If you need N nodes, simply deploy the chart N times.
+Currently erigon doesn't allow you to announce a a different discovery port, which would be a requirement to run multiple replicas within the same chart.
 
 ```yaml
-replicas: 5
+replicas: 1
 
 p2pNodePort:
   enabled: true
-  startAt: 30000
-  portsOverwrite:
-    "3": 32000
+  port: 31000
 ```
-
-This would create 5 nodes, exposed via Node Port services with the following configuration:
-- Node 0: `30000`
-- Node 1: `30001`
-- Node 2: `30002`
-- Node 3: `32000`
-- Node 4: `30004`
 
 ## Exposing more APIs via the RPC Daemon
 

--- a/charts/erigon/README.md.gotmpl
+++ b/charts/erigon/README.md.gotmpl
@@ -26,24 +26,20 @@ extraArgs:
 
 ## Exposing the P2P service via NodePort
 
-This will make your nodes accessible via the Internet using services of type [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport). It will allocate a service definition and a pre-defined node port for each replica. The allocation starts at `p2pNodePort.startAt`. When using `p2pNodePort.enabled` the exposed IP address on your ENR record will be the "External IP" of the node where the pod is running.
+This will make your node accessible via the Internet using a service of type [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport).
+When using `p2pNodePort.enabled` the exposed IP address on your ENR record will be the "External IP" of the node where the pod is running.
+
+**Limitations:** You can only run a single replica per chart deployment when using `p2pNodePort.enabled=true`.If you need N nodes, simply deploy the chart N times.
+Currently erigon doesn't allow you to announce a a different discovery port, which would be a requirement to run multiple replicas within the same chart.
 
 ```yaml
-replicas: 5
+replicas: 1
 
 p2pNodePort:
   enabled: true
-  startAt: 30000
-  portsOverwrite:
-    "3": 32000
+  port: 31000
 ```
 
-This would create 5 nodes, exposed via Node Port services with the following configuration:
-- Node 0: `30000`
-- Node 1: `30001`
-- Node 2: `30002`
-- Node 3: `32000`
-- Node 4: `30004`
 
 ## Exposing more APIs via the RPC Daemon
 

--- a/charts/erigon/templates/_helpers.tpl
+++ b/charts/erigon/templates/_helpers.tpl
@@ -62,7 +62,11 @@ Create the name of the service account to use
 {{- end }}
 
 {{- define "erigon.p2pPort" -}}
+{{- if .Values.p2pNodePort.enabled }}
+{{- print .Values.p2pNodePort.port }}
+{{- else }}
 {{- printf "30303" -}}
+{{- end }}
 {{- end -}}
 
 {{- define "erigon.httpPort" -}}
@@ -75,4 +79,12 @@ Create the name of the service account to use
 
 {{- define "erigon.metricsPortRPCDaemon" -}}
 {{- printf "6061" -}}
+{{- end -}}
+
+{{- define "erigon.replicas" -}}
+{{- if .Values.p2pNodePort.enabled }}
+{{- print 1 }}
+{{ else }}
+{{- print .Values.replicas }}
+{{- end}}
 {{- end -}}

--- a/charts/erigon/templates/service.p2p.nodeport.yaml
+++ b/charts/erigon/templates/service.p2p.nodeport.yaml
@@ -1,19 +1,14 @@
 {{- if .Values.p2pNodePort.enabled -}}
 
-{{- range $i, $e := until (int $.Values.replicas) }}
-
-{{- $port := add $.Values.p2pNodePort.startAt $i -}}
-{{- if hasKey $.Values.p2pNodePort.portsOverwrite ($i | toString) -}}
-  {{ $port = index $.Values.p2pNodePort.portsOverwrite ($i | toString) }}
-{{- end }}
+{{- $port := $.Values.p2pNodePort.port -}}
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "erigon.fullname" $ }}-p2p-{{ $i }}
+  name: {{ include "erigon.fullname" $ }}-p2p-0
   labels:
     {{- include "erigon.labels" $ | nindent 4 }}
-    pod: {{ include "erigon.fullname" $ }}-{{ $i }}
+    pod: {{ include "erigon.fullname" $ }}-0
     type: p2p
 spec:
   type: NodePort
@@ -31,8 +26,5 @@ spec:
       nodePort: {{ $port }}
   selector:
     {{- include "erigon.selectorLabels" $ | nindent 4 }}
-    statefulset.kubernetes.io/pod-name: {{ include "erigon.fullname" $ }}-{{ $i }}
-
-{{- end }}
-
+    statefulset.kubernetes.io/pod-name: "{{ include "erigon.fullname" $ }}-0"
 {{- end }}

--- a/charts/erigon/templates/statefulset.yaml
+++ b/charts/erigon/templates/statefulset.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- toYaml .Values.annotations | nindent 4 }}
 spec:
   podManagementPolicy: {{ .Values.podManagementPolicy }}
-  replicas: {{ .Values.replicas }}
+  replicas: {{ include "erigon.replicas" . }}
   selector:
     matchLabels:
       {{- include "erigon.selectorLabels" . | nindent 6 }}
@@ -106,14 +106,12 @@ spec:
             - name: storage
               mountPath: "/data"
           ports:
-          {{- if not (.Values.p2pNodePort.enabled) }}
             - name: p2p-tcp
               containerPort: {{ include "erigon.p2pPort" . }}
               protocol: TCP
             - name: p2p-udp
               containerPort: {{ include "erigon.p2pPort" . }}
               protocol: UDP
-          {{- end }}
             - name: metrics
               containerPort: {{ include "erigon.metricsPort" . }}
               protocol: TCP
@@ -179,42 +177,6 @@ spec:
           {{- if .Values.extraEnv }}
             {{- toYaml .Values.extraEnv | nindent 12 }}
           {{- end }}
-      {{- if .Values.p2pNodePort.enabled }}
-        - name: port-forward-p2p-udp
-          image: "{{ .Values.p2pNodePort.portForwardContainer.image.repository }}:{{ .Values.p2pNodePort.portForwardContainer.image.tag }}"
-          imagePullPolicy: "{{ .Values.p2pNodePort.portForwardContainer.image.pullPolicy }}"
-          command:
-            - sh
-            - -ac
-            - >
-              . /env/init-nodeport;
-              exec socat udp4-recvfrom:{{ include "erigon.p2pPort" . }},fork "udp4-sendto:localhost:$EXTERNAL_PORT"
-          ports:
-            - name: p2p-udp
-              containerPort: {{ include "erigon.p2pPort" . }}
-              protocol: UDP
-          volumeMounts:
-            - name: env-nodeport
-              mountPath: /env
-              readOnly: true
-        - name: port-forward-p2p-tcp
-          image: "{{ .Values.p2pNodePort.portForwardContainer.image.repository }}:{{ .Values.p2pNodePort.portForwardContainer.image.tag }}"
-          imagePullPolicy: "{{ .Values.p2pNodePort.portForwardContainer.image.pullPolicy }}"
-          command:
-            - sh
-            - -ac
-            - >
-              . /env/init-nodeport;
-              exec socat tcp-listen:{{ include "erigon.p2pPort" . }},reuseaddr,fork "tcp:localhost:$EXTERNAL_PORT"
-          ports:
-            - name: p2p-tcp
-              containerPort: {{ include "erigon.p2pPort" . }}
-              protocol: TCP
-          volumeMounts:
-            - name: env-nodeport
-              mountPath: /env
-              readOnly: true
-      {{- end }}
       {{- if .Values.extraContainers }}
         {{ toYaml .Values.extraContainers | nindent 8}}
       {{- end }}

--- a/charts/erigon/values.yaml
+++ b/charts/erigon/values.yaml
@@ -31,18 +31,14 @@ customCommand: [] # Only change this if you need to change the default command
 customCommandRPCDaemon: [] # Only change this if you need to change the default command
 
 # When p2pNodePort is enabled, your P2P port will be exposed via service type NodePort.
-# This will generate a service for each replica, with a port binding via NodePort.
 # This is useful if you want to expose and announce your node to the Internet.
+# Limitation: You can only one have one replica when exposing via NodePort.
+#             Check the chart README.md for more details
 p2pNodePort:
   # -- Expose P2P port via NodePort
   enabled: false
-  # -- Port used to start
-  startAt: 31000
-  # -- Overwrite a port for specific replicas
-  # @default -- See `values.yaml` for example
-  portsOverwrite: {}
-  #  "0": 32345
-  #  "3": 32348
+  # -- NodePort to be used
+  port: 31000
   initContainer:
     image:
       # -- Container image to fetch nodeport information


### PR DESCRIPTION
NodePort with the intermediary socat proxy wasn't working well with the P2P layer. This change has the limitation that you can only run 1 Replica when using NodePort, but that can be worked around by deploying the chart multiple times.