### PR TITLE
geth: add extraContainerPorts

### DIFF
--- a/charts/geth/Chart.yaml
+++ b/charts/geth/Chart.yaml
@@ -9,7 +9,7 @@ icon: https://launchpad.ethereum.org/static/media/gethereum-mascot-circle.75cbd3
 sources:
   - https://github.com/ethereum/go-ethereum
 type: application
-version: 0.2.0
+version: 0.2.1
 maintainers:
   - name: skylenet
     email: rafael@skyle.net

--- a/charts/geth/README.md
+++ b/charts/geth/README.md
@@ -1,7 +1,7 @@
 
 # geth
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Go Ethereum (Geth for short) is one of the original implementations of the Ethereum protocol. Currently, it is the most widespread client with the biggest user base and variety of tooling for users and developers. It is written in Go, fully open source and licensed under the GNU LGPL v3
 
@@ -20,9 +20,10 @@ Go Ethereum (Geth for short) is one of the original implementations of the Ether
 | config | string | See `values.yaml` for example | TOML config file |
 | customCommand | list | `[]` | Command replacement for the geth container |
 | extraArgs | list | `[]` | Extra args for the geth container |
+| extraContainerPorts | list | `[]` | Additional ports for the main container |
 | extraContainers | list | `[]` | Additional containers |
 | extraEnv | list | `[]` | Additional env variables |
-| extraPorts | list | `[]` | Additional ports. Useful when using extraContainers |
+| extraPorts | list | `[]` | Additional ports. Useful when using extraContainers or extraContainerPorts |
 | extraVolumeMounts | list | `[]` | Additional volume mounts |
 | extraVolumes | list | `[]` | Additional volumes |
 | fullnameOverride | string | `""` | Overrides the chart's computed fullname |

--- a/charts/geth/templates/statefulset.yaml
+++ b/charts/geth/templates/statefulset.yaml
@@ -110,6 +110,9 @@ spec:
               mountPath: "/config"
               readOnly: true
           ports:
+            {{- if .Values.extraContainerPorts }}
+              {{ toYaml .Values.extraContainerPorts | nindent 12}}
+            {{- end }}
             - name: p2p-tcp
               containerPort: {{ include "geth.p2pPort" . }}
               protocol: TCP

--- a/charts/geth/values.yaml
+++ b/charts/geth/values.yaml
@@ -213,8 +213,11 @@ extraVolumes: []
 # -- Additional volume mounts
 extraVolumeMounts: []
 
-# -- Additional ports. Useful when using extraContainers
+# -- Additional ports. Useful when using extraContainers or extraContainerPorts
 extraPorts: []
+
+# -- Additional ports for the main container
+extraContainerPorts: []
 
 # -- Additional env variables
 extraEnv: []


### PR DESCRIPTION
So that we can test and configure the new `--authrpc.port` without building it already into the chart.