### PR TITLE
fix(nimbus): Change port http-rpc to http-api

### DIFF
--- a/charts/nimbus/Chart.yaml
+++ b/charts/nimbus/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://launchpad.ethereum.org/static/media/nimbus-circle.2752d77b.png
 sources:
   - https://github.com/status-im/nimbus-eth2
 type: application
-version: 0.2.1
+version: 0.3.0
 maintainers:
   - name: skylenet
     email: rafael@skyle.net

--- a/charts/nimbus/README.md
+++ b/charts/nimbus/README.md
@@ -1,7 +1,7 @@
 
 # nimbus
 
-![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 An open-source Ethereum consensus layer client, written in Java
 

--- a/charts/nimbus/templates/service-headless.yaml
+++ b/charts/nimbus/templates/service-headless.yaml
@@ -16,9 +16,9 @@ spec:
       protocol: UDP
       name: p2p-udp
     - port: {{ include "nimbus.restPort" . }}
-      targetPort: http-rpc
+      targetPort: http-api
       protocol: TCP
-      name: http-rpc
+      name: http-api
     - port: {{ include "nimbus.metricsPort" . }}
       targetPort: metrics
       protocol: TCP

--- a/charts/nimbus/templates/service.yaml
+++ b/charts/nimbus/templates/service.yaml
@@ -16,9 +16,9 @@ spec:
       protocol: UDP
       name: p2p-udp
     - port: {{ include "nimbus.restPort" . }}
-      targetPort: http-rpc
+      targetPort: http-api
       protocol: TCP
-      name: http-rpc
+      name: http-api
     - port: {{ include "nimbus.metricsPort" . }}
       targetPort: metrics
       protocol: TCP

--- a/charts/nimbus/templates/statefulset.yaml
+++ b/charts/nimbus/templates/statefulset.yaml
@@ -112,7 +112,7 @@ spec:
             - name: p2p-udp
               containerPort: {{ include "nimbus.p2pPort" . }}
               protocol: UDP
-            - name: http-rpc
+            - name: http-api
               containerPort: {{ include "nimbus.restPort" . }}
               protocol: TCP
             - name: metrics

--- a/charts/nimbus/values.yaml
+++ b/charts/nimbus/values.yaml
@@ -83,7 +83,7 @@ annotations: {}
 # @default -- See `values.yaml`
 livenessProbe:
   tcpSocket:
-    port: http-rpc
+    port: http-api
   initialDelaySeconds: 60
   periodSeconds: 120
 
@@ -91,7 +91,7 @@ livenessProbe:
 # @default -- See `values.yaml`
 readinessProbe:
   tcpSocket:
-    port: http-rpc
+    port: http-api
   initialDelaySeconds: 10
   periodSeconds: 10
 


### PR DESCRIPTION
Renames the Nimbus pod/service port `http-rpc` to `http-api` to align with the other conensus charts