### PR TITLE
feat(dshackle): Bump version

### DIFF
--- a/charts/dshackle/Chart.yaml
+++ b/charts/dshackle/Chart.yaml
@@ -8,7 +8,7 @@ icon: https://avatars.githubusercontent.com/u/49622339?s=200&v=4
 sources:
   - https://github.com/emeraldpay/dshackle
 type: application
-version: 0.1.1
+version: 0.1.2
 maintainers:
   - name: skylenet
     email: rafael@skyle.net

--- a/charts/dshackle/README.md
+++ b/charts/dshackle/README.md
@@ -1,7 +1,7 @@
 
 # dshackle
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Emerald Dshackle is a Fault Tolerant Load Balancer for Blockchain API. Support for standard Bitcoin and Ethereum JSON RPC API over HTTP and WebSocket.
 


### PR DESCRIPTION
Chart Releaser wants to upload a new dshackle version: https://github.com/skylenet/ethereum-helm-charts/runs/8064796693?check_suite_focus=true