### PR TITLE
feat: allow to set a container security context for OpenShift deployments

### DIFF
--- a/charts/dshackle/Chart.yaml
+++ b/charts/dshackle/Chart.yaml
@@ -8,7 +8,7 @@ icon: https://avatars.githubusercontent.com/u/49622339?s=200&v=4
 sources:
   - https://github.com/emeraldpay/dshackle
 type: application
-version: 0.1.2
+version: 0.2.0
 maintainers:
   - name: skylenet
     email: rafael@skyle.net

--- a/charts/dshackle/Chart.yaml
+++ b/charts/dshackle/Chart.yaml
@@ -8,7 +8,7 @@ icon: https://avatars.githubusercontent.com/u/49622339?s=200&v=4
 sources:
   - https://github.com/emeraldpay/dshackle
 type: application
-version: 0.2.0
+version: 0.1.3
 maintainers:
   - name: skylenet
     email: rafael@skyle.net

--- a/charts/dshackle/README.md
+++ b/charts/dshackle/README.md
@@ -1,7 +1,7 @@
 
 # dshackle
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Emerald Dshackle is a Fault Tolerant Load Balancer for Blockchain API. Support for standard Bitcoin and Ethereum JSON RPC API over HTTP and WebSocket.
 

--- a/charts/dshackle/README.md
+++ b/charts/dshackle/README.md
@@ -1,7 +1,7 @@
 
 # dshackle
 
-![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Emerald Dshackle is a Fault Tolerant Load Balancer for Blockchain API. Support for standard Bitcoin and Ethereum JSON RPC API over HTTP and WebSocket.
 
@@ -24,8 +24,8 @@ Emerald Dshackle is a Fault Tolerant Load Balancer for Blockchain API. Support f
 | affinity | object | `{}` | Affinity configuration for pods |
 | annotations | object | `{}` | Annotations for the StatefulSet |
 | config | string | See `values.yaml` | Config file |
+| containerSecurityContext | object | `{}` |  |
 | customArgs | list | `[]` | Custom args for the dshackle container |
-| containerSecurityContext | object | See `values.yaml` | The security context for containers |
 | customCommand | list | `[]` | Command replacement for the dshackle container |
 | extraContainers | list | `[]` | Additional containers |
 | extraEnv | list | `[]` | Additional env variables |

--- a/charts/dshackle/README.md
+++ b/charts/dshackle/README.md
@@ -25,6 +25,7 @@ Emerald Dshackle is a Fault Tolerant Load Balancer for Blockchain API. Support f
 | annotations | object | `{}` | Annotations for the StatefulSet |
 | config | string | See `values.yaml` | Config file |
 | customArgs | list | `[]` | Custom args for the dshackle container |
+| containerSecurityContext | object | See `values.yaml` | The security context for containers |
 | customCommand | list | `[]` | Command replacement for the dshackle container |
 | extraContainers | list | `[]` | Additional containers |
 | extraEnv | list | `[]` | Additional env variables |

--- a/charts/dshackle/templates/statefulset.yaml
+++ b/charts/dshackle/templates/statefulset.yaml
@@ -55,6 +55,8 @@ spec:
           args:
             {{- toYaml .Values.customArgs | nindent 12}}
           {{- end }}
+          securityContext:
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
           volumeMounts:
             {{- if .Values.extraVolumeMounts }}
               {{ toYaml .Values.extraVolumeMounts | nindent 12}}

--- a/charts/dshackle/values.yaml
+++ b/charts/dshackle/values.yaml
@@ -153,6 +153,14 @@ securityContext:
   runAsNonRoot: true
   runAsUser: 10001
 
+containerSecurityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
 serviceAccount:
   # -- Specifies whether a service account should be created
   create: true


### PR DESCRIPTION
OpenShift is notoriously strict on permissions and to deploy this chart without warnings we need to be able to set container level security contexts as well.

```
would violate PodSecurity "restricted:v1.24": allowPrivilegeEscalation != false (container "dshackle" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "dshackle" must set securityContext.capabilities.drop=["ALL"]), seccompProfile (pod or container "dshackle" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
```

default `helm create` generates `podSecurityContext` for pods and `securityContext` for containers, but to not break backwards compatibility I used the other convention you see which is `containerSecurityContext`.